### PR TITLE
[Fix] Limit the size of the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ import (
 )
 
 func main() {
-	// The function takes 2 parameters: the path to the folder containing the regexes, and if the cache can be enabled
-	dd, err := NewDeviceDetector("regexes", false)
+	// The function takes 2 parameters: the path to the folder containing the regexes, and the parameters for the cache (isEnabled: bool, size: int)
+	dd, err := NewDeviceDetector("regexes", &CacheParams{true, 100})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/device_detector.go
+++ b/device_detector.go
@@ -50,10 +50,15 @@ type DeviceDetector struct {
 	SkipBotDetection      bool
 }
 
+type CacheParams struct {
+	isEnabled bool
+	size      int
+}
+
 // Initialize the device detector.
 // - dir: path of the folder containing the regexes to parse the userAgent
 // - enableCache: if true, the cache will be enabled.
-func NewDeviceDetector(dir string, enableCache bool) (*DeviceDetector, error) {
+func NewDeviceDetector(dir string, cacheParams *CacheParams) (*DeviceDetector, error) {
 	vp, err := parser.NewVendor(filepath.Join(dir, parser.FixtureFileVendor))
 	if err != nil {
 		return nil, err
@@ -70,8 +75,12 @@ func NewDeviceDetector(dir string, enableCache bool) (*DeviceDetector, error) {
 		osParsers:    []parser.OsParser{osp},
 	}
 
-	if enableCache {
-		d.cache = NewCache()
+	if cacheParams.isEnabled {
+		if cacheParams.size == 0 {
+			cacheParams.size = CACHE_DEFAULT_SIZE
+		}
+
+		d.cache = NewCache(cacheParams.size)
 	}
 
 	clientDir := filepath.Join(dir, "client")

--- a/device_detector_cache.go
+++ b/device_detector_cache.go
@@ -1,23 +1,47 @@
 package devicedetector
 
-import "sync"
+import (
+	"container/list"
+	"sync"
+)
+
+const CACHE_DEFAULT_SIZE int = 1000
 
 type Cache struct {
-	cache map[string]*DeviceInfo
-	mu    sync.RWMutex
+	cache    map[string]*DeviceInfo
+	size     int
+	key_list *list.List
+	mu       sync.RWMutex
 }
 
-func NewCache() *Cache {
+func NewCache(size int) *Cache {
 	return &Cache{
-		cache: make(map[string]*DeviceInfo),
-		mu:    sync.RWMutex{},
+		cache:    make(map[string]*DeviceInfo),
+		size:     size,
+		key_list: list.New(),
+		mu:       sync.RWMutex{},
 	}
 }
 
 // Associate a deviceInfo element with the userAgent
 func (d *Cache) Add(ua string, deviceInfo *DeviceInfo) {
 	d.mu.Lock()
+
+	// Add ua to the cache
 	d.cache[ua] = deviceInfo
+
+	// Add ua to the key_list and keep control of the size of the cache
+	d.key_list.PushBack(ua)
+	if d.key_list.Len() > d.size {
+		// Remove exceeding ua from the list
+		most_recent_ua := d.key_list.Front()
+
+		d.key_list.Remove(most_recent_ua)
+
+		// Remove exceeding ua from the cache
+		delete(d.cache, (most_recent_ua.Value).(string))
+	}
+
 	d.mu.Unlock()
 }
 
@@ -34,5 +58,6 @@ func (d *Cache) Lookup(ua string) (deviceInfo *DeviceInfo, hit bool) {
 func (d *Cache) Purge() {
 	d.mu.Lock()
 	d.cache = make(map[string]*DeviceInfo)
+	d.key_list.Init()
 	d.mu.Unlock()
 }

--- a/device_test.go
+++ b/device_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var dd, _ = NewDeviceDetector("regexes", false)
+var dd, _ = NewDeviceDetector("regexes", &CacheParams{false, 0})
 
 func TestParseInvalidUA(t *testing.T) {
 	info := dd.Parse(`12345`)

--- a/parser/client/client_factory.go
+++ b/parser/client/client_factory.go
@@ -30,7 +30,7 @@ func NewClientParsers(dir string, names []string) []ClientParser {
 			r[i] = f(dir)
 		}
 		if r[i] == nil {
-			fmt.Printf("Client is null:" + name)
+			fmt.Printf("Client is null: %s", name)
 		}
 
 	}


### PR DESCRIPTION
The `NewDeviceDetector(...)` method no longer takes a boolean to enable or disable the cache. Instead, it takes a struct `CacheConfig{isEnabled: bool, size: int}` to also specify the maximum size of the cache. It prevents unbound memory usage.